### PR TITLE
Tweaks to 'main' functionality

### DIFF
--- a/appliedEP.py
+++ b/appliedEP.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python2.7
 # -*- coding: utf-8 -*-1
 from __future__ import division
+import sys
 import random
 # import compiledGradient
 import numpy
@@ -280,12 +281,17 @@ def valid(string):
 		return True
 
 def main():
-	newPopulation= createNKeyboards(50)
+	if len(sys.argv) != 3:
+		sys.exit('Usage: ' + sys.argv[0] + ' [numKeyboards] [numGenerations]')
+	numKeyboards = int(sys.argv[1])
+	numGenerations = int(sys.argv[2])
+
+	newPopulation= createNKeyboards(numKeyboards)
 	i = 0
 	bestScore = 100
 	bestKeyboard = ''
 	while True:
-		if i == 1000:
+		if i == numGenerations:
 			print("--- %s seconds ---" % (time.time() - start_time))
 			break
 		fitnesses = stringFitnesses(theInput, newPopulation)

--- a/appliedEP.py
+++ b/appliedEP.py
@@ -279,30 +279,34 @@ def valid(string):
 	else:
 		return True
 
-newPopulation= createNKeyboards(50)
-i = 0
-bestScore = 100
-bestKeyboard = ''
-while True:
-	if i == 1000:
-		print("--- %s seconds ---" % (time.time() - start_time))
-		break
-	fitnesses = stringFitnesses(theInput, newPopulation)
-	avg = sum(fitnesses)/len(fitnesses)
-	minIndex = fitnesses.index(min(fitnesses))
+def main():
+	newPopulation= createNKeyboards(50)
+	i = 0
+	bestScore = 100
+	bestKeyboard = ''
+	while True:
+		if i == 1000:
+			print("--- %s seconds ---" % (time.time() - start_time))
+			break
+		fitnesses = stringFitnesses(theInput, newPopulation)
+		avg = sum(fitnesses)/len(fitnesses)
+		minIndex = fitnesses.index(min(fitnesses))
 
-	if min(fitnesses) < bestScore:
-		bestScore = min(fitnesses)
-		bestKeyboard = str(newPopulation[minIndex])
-	count = Counter(newPopulation)
-	print i, avg, min(fitnesses), newPopulation[minIndex], bestScore, bestKeyboard, count.most_common()[0]
+		if min(fitnesses) < bestScore:
+			bestScore = min(fitnesses)
+			bestKeyboard = str(newPopulation[minIndex])
+		count = Counter(newPopulation)
+		print i, avg, min(fitnesses), newPopulation[minIndex], bestScore, bestKeyboard, count.most_common()[0]
 
-	# selected = eliteRouletteDeletion(fitnesses, 10)
-	# newPopulation = newMateAndMutate(fitnesses, selected, newPopulation) #repetition converges around generation 30
-	selected = eliteRouletteSelection(fitnesses, 10) #this repetition stays low, around 4-8 for at least 150 generations, likely more
-	newPopulation = mateAndMutate(fitnesses, selected,newPopulation)
-	i += 1
-print newPopulation[0]
+		# selected = eliteRouletteDeletion(fitnesses, 10)
+		# newPopulation = newMateAndMutate(fitnesses, selected, newPopulation) #repetition converges around generation 30
+		selected = eliteRouletteSelection(fitnesses, 10) #this repetition stays low, around 4-8 for at least 150 generations, likely more
+		newPopulation = mateAndMutate(fitnesses, selected,newPopulation)
+		i += 1
+	print newPopulation[0]
+
+if __name__ == '__main__':
+	main()
 
 
 

--- a/appliedEP.py
+++ b/appliedEP.py
@@ -290,6 +290,11 @@ def main():
 	i = 0
 	bestScore = 100
 	bestKeyboard = ''
+
+	printList = ["#", "Avg. Fitness", "Min. Fitness", "Min. Fitness Keyboard", "Best Score", "Best Keyboard", "Most Common (Keyboard, Occurences)"]
+	# 15 spaces for scores, 30 for keyboard strings
+	rowFormat ="{:<5}" + "{:<15}"*2 + "{:<30}" + "{:<15}" + "{:<30}"*2
+	print rowFormat.format(*printList)
 	while True:
 		if i == numGenerations:
 			print("--- %s seconds ---" % (time.time() - start_time))
@@ -302,7 +307,7 @@ def main():
 			bestScore = min(fitnesses)
 			bestKeyboard = str(newPopulation[minIndex])
 		count = Counter(newPopulation)
-		print i, avg, min(fitnesses), newPopulation[minIndex], bestScore, bestKeyboard, count.most_common()[0]
+		print rowFormat.format(i, avg, min(fitnesses), newPopulation[minIndex], bestScore, bestKeyboard, count.most_common()[0])
 
 		# selected = eliteRouletteDeletion(fitnesses, 10)
 		# newPopulation = newMateAndMutate(fitnesses, selected, newPopulation) #repetition converges around generation 30


### PR DESCRIPTION
Three changes to `appliedEP.py`:
1. Create a distinct main function.
2. Accept number of keyboards (as passed to `createNKeyboards`) and number of generations (the break condition for the main loop) as command line arguments, like so: `python appliedEP.py 50 1000` (for 50 keyboards, 1000 generations).
3. Format the print strings to be arranged in a (sort of) table, with headers for the columns.  Output looks like this:

```
#    Avg. Fitness   Min. Fitness   Min. Fitness Keyboard         Best Score     Best Keyboard                 Most Common (Keyboard, Occurences)
0    2.03418847048  1.61850061088  bjhsnuic^gmoket adqpwxlzyfrv  1.61850061088  bjhsnuic^gmoket adqpwxlzyfrv  ('urxkwzdbhlvqmgfcjoe aty^nisp', 1)
1    2.022482979    1.70613578239  xekniargpuvhm^q ycbjlszdtwfo  1.61850061088  bjhsnuic^gmoket adqpwxlzyfrv  ('pjz^wicvaftosydm qknhgxbrleu', 2)
...
```

Minor changes all around, but should hopefully make interacting with the program a bit more comfortable.
